### PR TITLE
Fix of service encoding in numalgo2

### DIFF
--- a/core.html
+++ b/core.html
@@ -166,7 +166,7 @@ service = 1*B64URL
 		<li>Replace common strings in key names and type value with appreviations from the abbreviations table below.</li>
 		<li>Convert to string, and remove unnecessary whitespace, such as spaces and newlines.</li>
 		<li>Base64URL Encode String</li>
-		<li>Add the period (.) and S</li>
+		<li>Prefix service with a period character (.) and S</li>
 	</ul>
 	
 	<p>Service decoding</p>

--- a/core.html
+++ b/core.html
@@ -150,7 +150,7 @@ purposecode = "A" / "E" / "V" / "I" / "D" / "S"
 keypurpose = 
 transform = "z"
 encnumbasis = 46*BASE58BTC
-service = "S" 1*B64URL
+service = 1*B64URL
     </pre>
 	
 	<ul>
@@ -158,7 +158,7 @@ service = "S" 1*B64URL
 		<li>Construct a multibase encoded, multicodec-encoded form of each public key to be included.</li>
 		<li>Prefix each encoded key with a period character (.) and single character from the purpose codes table below.</li>
 		<li>Append the encoded key to the DID.</li>
-		<li>Encode and append a service type if desired as described below.</li>
+		<li>Encode and append a service type to the end of the peer DID if desired as described below.</li>
 	</ul>
 	<p>Service encoding</p>
 	<ul>
@@ -166,7 +166,7 @@ service = "S" 1*B64URL
 		<li>Replace common strings in key names and type value with appreviations from the abbreviations table below.</li>
 		<li>Convert to string, and remove unnecessary whitespace, such as spaces and newlines.</li>
 		<li>Base64URL Encode String</li>
-		<li>Add the period (.) and S (for the service) </li>
+		<li>Add the period (.) and S</li>
 	</ul>
 	
 	<p>Service decoding</p>

--- a/core.html
+++ b/core.html
@@ -150,7 +150,7 @@ purposecode = "A" / "E" / "V" / "I" / "D" / "S"
 keypurpose = 
 transform = "z"
 encnumbasis = 46*BASE58BTC
-service = "S" 1*B64URL
+service = 1*B64URL
     </pre>
 	
 	<ul>
@@ -158,7 +158,7 @@ service = "S" 1*B64URL
 		<li>Construct a multibase encoded, multicodec-encoded form of each public key to be included.</li>
 		<li>Prefix each encoded key with a period character (.) and single character from the purpose codes table below.</li>
 		<li>Append the encoded key to the DID.</li>
-		<li>Encode and append a service type if desired as described below.</li>
+		<li>Encode and append a service type to the end of the peer DID if desired as described below.</li>
 	</ul>
 	<p>Service encoding</p>
 	<ul>
@@ -166,7 +166,7 @@ service = "S" 1*B64URL
 		<li>Replace common strings in key names and type value with abbreviations from the abbreviations table below.</li>
 		<li>Convert to string, and remove unnecessary whitespace, such as spaces and newlines.</li>
 		<li>Base64URL Encode String (no padding)</li>
-		<li>Add the period (.) and S (for the service) </li>
+		<li>Prefix encoded service with a period character (.) and S</li>
 	</ul>
 	
 	<p>Service decoding</p>

--- a/core.html
+++ b/core.html
@@ -166,7 +166,7 @@ service = 1*B64URL
 		<li>Replace common strings in key names and type value with appreviations from the abbreviations table below.</li>
 		<li>Convert to string, and remove unnecessary whitespace, such as spaces and newlines.</li>
 		<li>Base64URL Encode String</li>
-		<li>Prefix service with a period character (.) and S</li>
+		<li>Prefix encoded service with a period character (.) and S</li>
 	</ul>
 	
 	<p>Service decoding</p>


### PR DESCRIPTION
- Error described in https://github.com/decentralized-identity/peer-did-method-spec/issues/34 fixed
- The spec was changed so that now the `service` can only be at the end of the peer DID (for the sake of simplicity of working with the regex)