### PR TITLE
fix: corrections and clarifications for did:peer:2

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -112,7 +112,7 @@ In addition to keys, `did:peer:2` can encode one or more [services](https://www.
 
 The service SHOULD follow the DID Core specification for services.
 
-For use with `did:peer:2`, service `id` attributes MUST be relative. The service MAY omit the `id`; however, this is NOT recommended (clarified).
+For use with `did:peer:2`, service `id` attributes MUST be relative. The service MAY omit the `id`; however, this is NOT RECOMMEDED (clarified).
 
 Consider the following service as input:
 
@@ -166,6 +166,7 @@ To encode a service:
     .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYWNjZXB0IjpbImRpZGNvbW0vdjIiXSwicm91dGluZ0tleXMiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ
     .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ
     ```
+    When encoding multiple services, they MUST be encoded individually and concatenated together. The services MUST NOT be encoded as a JSON list.
 
 Finally, to create the DID, concatenate the following values:
 

--- a/spec/core.md
+++ b/spec/core.md
@@ -213,7 +213,7 @@ The `id` value of the Document, verification method, and service objects MUST be
 
 When Resolving the peer DID into a DID Document, the process is reversed:
 
-* Start with an empty document with the DID Core context (clarified):
+* Start with an empty document with the DID Core context and [Multikey context](https://www.w3.org/TR/vc-data-integrity/#multikey) (clarified):
     ```json
     {
         "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1"]

--- a/spec/core.md
+++ b/spec/core.md
@@ -212,6 +212,12 @@ did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrG
 
 ##### Resolving a `did:peer:2`
 
+::: note
+Below is the normative approach to resolving did:peer:2 DIDs. However, it is often the case that the resolved value is only used within a particular component. In this case, some of these rules may be relaxed. For instance, the verification material may be transformed into a JWK or other representation if the resolving component is more accustomed to working with those key representations. It is not strictly necessary to first represent the document as described here only to immediately transform it into the more familiar representation. Shortcuts like these are not problematic unless they impact the function of the DID Document.
+
+The `id` value of the Document, verification method, and service objects MUST be set as outlined below. These values are used to reference elements of the document and must be consistent across implementations regardless of shortcuts taken within the resolver.
+:::
+
 When Resolving the peer DID into a DID Document, the process is reversed:
 
 * Start with an empty document with the DID Core context (clarified):
@@ -235,18 +241,24 @@ When Resolving the peer DID into a DID Document, the process is reversed:
     * Remove the period (.) and the Purpose prefix. Consider the remaining string the "encoded key."
     * Create an empty object. Consider this value the "verification method."
     * Set the `type` of the verification method according to the multicodec prefix using the lookup table above (clarified).
-    * Set the `id` of the verification method to `#{encoded key}` (clarified); for example:
+    * Set the `id` of the verification method to `#key-N` where `N` is an incrementing number starting at `1` (clarified). The keys MUST be processed in the order they appear in the DID string. For example, if you have the DID (whitespace added for example only):
         ```
-        #z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc
+        did:peer:2
+            .Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc
+            .Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR
+            .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ
+            .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ
         ```
+        The key with purpose code `V` and encoded key value `z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc` will have the `id`: `#key-1`.
+        The key with purpose code `E` and encoded key value `z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR` will have the `id`: `#key-2`.
     * Set the `controller` of the verification method to the value of the DID being resolved.
     * Set the `publicKeyMultibase` of the verification method to the value of the encoded key.
     * Append this object to `verificationMethod` of the document (clarified).
-    * Append a reference to the verification method to the appropriate verification relationship. The reference should be the exact value used in the `id` of the verification method (clarified). For example, if the purpose of the key was `V` and using the `id` from the example above:
+    * Append a reference to the verification method to the appropriate verification relationship, using the lookup table above. The reference should be the exact value used in the `id` of the verification method (clarified). For example, using the DID above and the key with purpose code `V`:
         ```
         {
           ... // Context and other elements previously added to the document
-          "authentication": [..., "#z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc"]
+          "authentication": [..., "#key-1"]
         }
         ```
 * For each element with a purpose corresponding to a service, transform the service and add to the DID Document:
@@ -269,25 +281,25 @@ It is  not possible to express a verification method not controlled by the contr
 {
   "@context": "https://www.w3.org/ns/did/v1",
   "id": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
-  "authentication": [
-    "#z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc"
-  ],
   "verificationMethod": [
     {
-      "id": "#z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc",
+      "id": "#key-1",
       "controller": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
       "type": "Ed25519VerificationKey2020",
       "publicKeyMultibase": "z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc"
     },
     {
-      "id": "#z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR",
+      "id": "#key-2",
       "controller": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
       "type": "X25519KeyAgreementKey2020",
       "publicKeyMultibase": "z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR"
     }
   ],
+  "authentication": [
+    "#key-1"
+  ],
   "keyAgreement": [
-    "#z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR"
+    "#key-2"
   ],
   "service": [
     {

--- a/spec/core.md
+++ b/spec/core.md
@@ -279,7 +279,11 @@ It is  not possible to express a verification method not controlled by the contr
 
 ```json
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1",
+    "https://w3id.org/security/suites/x25519-2020/v1"
+  ],
   "id": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
   "verificationMethod": [
     {

--- a/spec/core.md
+++ b/spec/core.md
@@ -84,7 +84,7 @@ service = 1*B64URL
 
 When generating a `did:peer:2`, take as inputs a set of keys and their purpose. Each key's purpose corresponds to the [Verification Relationship](https://www.w3.org/TR/did-core/#verification-relationships) it will hold in the DID Document generated from the DID.
 
-Abstractly, these inputs may look like the following:
+Abstractly, these inputs may look like the following (in this example, the keys are already multibase, multicodec encoded values):
 
 ```json
 [
@@ -99,9 +99,9 @@ Abstractly, these inputs may look like the following:
 ]
 ```
 
-To encode these keys:
+To encode the input keys:
 
-* Construct a multibase, multicodec form of each public key to be included.
+* Construct a [multibase](https://github.com/multiformats/multibase), [multicodec](https://github.com/multiformats/multicodec) form of each public key to be included.
 * Prefix each encoded key with a period character (.) and single character from the purpose codes table below.
 * Concatenate the prefixed encoded keys. The inputs above will result in:
     ```
@@ -203,13 +203,6 @@ did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrG
 | **S**        | Service                       |
 
 
-###### Multicodec Prefix Name to Verification Method Type (clarified)
-
-| Multicodec Prefix Name             | Verification Method Type   |
-|------------------------------------|----------------------------|
-| ed25519-pub                        | Ed25519VerificationKey2020 |
-| x25519-pub                         | X25519KeyAgreementKey2020  |
-
 ##### Resolving a `did:peer:2`
 
 ::: note
@@ -223,24 +216,16 @@ When Resolving the peer DID into a DID Document, the process is reversed:
 * Start with an empty document with the DID Core context (clarified):
     ```json
     {
-        "@context": ["https://www.w3.org/ns/did/v1"]
+        "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1"]
     }
     ```
-    * If any of the keys in the DID are ed25519, add the following context:
-        ```
-        https://w3id.org/security/suites/ed25519-2020/v1
-        ```
-    * If any of the keys in the DID are x25519, add the following context:
-        ```
-        https://w3id.org/security/suites/x25519-2020/v1
-        ```
 * Set the `id` of the document to the DID being resolved.
 * Optionally, set the `alsoKnownAs` to the `did:peer:3` value corresponding to the DID being resolved.
 * Split the DID string into elements.
 * For each element with a purpose corresponding to a key, transform keys into verification methods in the DID Document:
     * Remove the period (.) and the Purpose prefix. Consider the remaining string the "encoded key."
     * Create an empty object. Consider this value the "verification method."
-    * Set the `type` of the verification method according to the multicodec prefix using the lookup table above (clarified).
+    * Set the `type` of the verification method to [`Multikey`](https://www.w3.org/TR/vc-data-integrity/#multikey) (clarified).
     * Set the `id` of the verification method to `#key-N` where `N` is an incrementing number starting at `1` (clarified). The keys MUST be processed in the order they appear in the DID string. For example, if you have the DID (whitespace added for example only):
         ```
         did:peer:2
@@ -281,21 +266,20 @@ It is  not possible to express a verification method not controlled by the contr
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security/suites/ed25519-2020/v1",
-    "https://w3id.org/security/suites/x25519-2020/v1"
+    "https://w3id.org/security/multikey/v1",
   ],
   "id": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
   "verificationMethod": [
     {
       "id": "#key-1",
       "controller": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
-      "type": "Ed25519VerificationKey2020",
+      "type": "Multikey",
       "publicKeyMultibase": "z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc"
     },
     {
       "id": "#key-2",
       "controller": "did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ",
-      "type": "X25519KeyAgreementKey2020",
+      "type": "Multikey",
       "publicKeyMultibase": "z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR"
     }
   ],

--- a/spec/core.md
+++ b/spec/core.md
@@ -69,7 +69,7 @@ The first iteration of this method left some elements of the encoding and decodi
 :::
 
 ::: example ABNF for peer DIDs
-``` json
+```
 peer-did-method-2 = "did:peer:2" 1*element 
 element = "." ( purposecode transform encnumbasis / service )
 purposecode = "A" / "E" / "V" / "I" / "D" / "S" 

--- a/spec/core.md
+++ b/spec/core.md
@@ -234,8 +234,8 @@ When Resolving the peer DID into a DID Document, the process is reversed:
             .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ
             .SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ
         ```
-        The key with purpose code `V` and encoded key value `z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc` will have the `id`: `#key-1`.
-        The key with purpose code `E` and encoded key value `z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR` will have the `id`: `#key-2`.
+        The key with purpose code `V` and encoded key value `z6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc` will have the `id` `#key-1`.
+        The key with purpose code `E` and encoded key value `z6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR` will have the `id` `#key-2`.
     * Set the `controller` of the verification method to the value of the DID being resolved.
     * Set the `publicKeyMultibase` of the verification method to the value of the encoded key.
     * Append this object to `verificationMethod` of the document (clarified).
@@ -316,7 +316,8 @@ It is  not possible to express a verification method not controlled by the contr
       },
       "id": "#service-1"
     }
-  ]
+  ],
+  "alsoKnownAs": ["did:peer:3zQmd6RdU6e2nDrLn1rjwdA5Buzq7wJwsv3WJ1AgrwKYJoLE"]
 }
 ```
 

--- a/spec/core.md
+++ b/spec/core.md
@@ -223,7 +223,7 @@ When Resolving the peer DID into a DID Document, the process is reversed:
 * Start with an empty document with the DID Core context (clarified):
     ```json
     {
-        "context": ["https://www.w3.org/ns/did/v1"]
+        "@context": ["https://www.w3.org/ns/did/v1"]
     }
     ```
     * If any of the keys in the DID are ed25519, add the following context:


### PR DESCRIPTION
As the author of the did:peer:4 generation algorithm, I obviously would like to see us all move to that method. However, it seems inevitable that we'll continue to use did:peer:2, at least for a while. To ease interop challenges across did:peer:2 implementations, I propose these clarifications to the did:peer:2 spec.

I believe this should address the concerns raised in #56.

cc @TelegramSam @FabioPinheiro @swcurran @genaris @TimoGlastra