### PR TITLE
fix: add support for multiple services in example regex

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -620,7 +620,7 @@ A convenient regex to match `peer` DIDs is:
 
 ::: example Matching regex
 ``` text
-^did:peer:(([01](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(\.(S)[0-9a-zA-Z=]*)?)))$
+^did:peer:(([01](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(\.(S)[0-9a-zA-Z=]*)*)))$
 ```
 :::
 


### PR DESCRIPTION
## Problem description

Accordingly to the specification, 0 or more services are supported, but the example regex `^did:peer:(([01](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(\.(S)[0-9a-zA-Z=]*)?)))$` in the spec allows only 0 or 1 service.

For example, a correct DID from the spec `did:peer:2.Vz6Mkj3PUd1WjvaDhNZhhhXQdz5UnZXmS7ehtx8bsPpD47kKc.Ez6LSg8zQom395jKLrGiBNruB9MM6V8PWuf2FpEy4uRFiqQBR.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9hbm90aGVyIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0yIl19fQ` will fail the check VS regex, because it contains 2 services.

This PR fixes regex to allow multiple services.

As other libraries are using this regex as a reference, for example, `sicpa-dlab/peer-did-jvm` uses it [here](https://github.com/sicpa-dlab/peer-did-jvm/blob/c3c405c7e3aa9ff12214553b334a2c53f54c4e0a/lib/src/main/kotlin/org/didcommx/peerdid/PeerDIDCreator.kt#L11-L25), it's important to correct it. 